### PR TITLE
Fixed app:testRelease failing by including shared package in androidSourceSets

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,10 @@ android {
 
     sourceSets {
         // Allows access to the java debug file[i.e TestingFakes.kt]
-        debug.java.srcDirs += 'src/debug/java'
+        final String sharedTestDir = 'src/debug/java'
+        test.java.srcDirs += sharedTestDir
+        androidTest.java.srcDirs += sharedTestDir
+//        debug.java.srcDirs += 'src/debug/java'
     }
 }
 

--- a/scripts/pre-commit-macos
+++ b/scripts/pre-commit-macos
@@ -2,8 +2,7 @@
 
 echo "Running lint check..."
 
-./gradlew clean app:ktlintCheck --daemon
-./gradlew app:testDebug --daemon
+./gradlew clean app:ktlintCheck app:testDebug --daemon
 
 status=$?
 

--- a/scripts/pre-push-macos
+++ b/scripts/pre-push-macos
@@ -2,7 +2,7 @@
 
 echo "Running test..."
 
-./gradlew app:testDebug --daemon --stacktrace
+./gradlew app:test --daemon --stacktrace
 
 status=$?
 


### PR DESCRIPTION
Fixed app:testRelease failing by including shared package in androidSourceSets